### PR TITLE
Add a note about the origins of Linode, which traces back to 1999

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,6 +27,7 @@ like I spend, I'll be glad!
 Notes:
 
 - The companies are sorted by the year of foundation.
+- Linode was spun-off from a company providing ColdFusion hosting (TheShore.net) that was founded in 1999.
 - Scaleway is a cloud division of Online.net (1999), itself subsidiary of the Iliad group (1990) owner also of the famous French ISP Free.
 - Vultr Holdings LLC is owned by Choopa LLC founded in 2000.
 - The Market numbers are extracted from the Wikipedia an other sources


### PR DESCRIPTION
TheShore.net was a ColdFusion hosting company started in 1999. Its core
components and codebase became the core of Linode, in 2003.

Fun-fact: parts of the core billing system still in-use in 2015 were originally
written for TheShore.net in 1999-2000. They may still be in-use today, but I
can't speak to that.

Full Disclosure: I was a developer / administrator there in a past life.

Signed-off-by: Tim Heckman <t@heckman.io>